### PR TITLE
[FEATURE] Add compatibility for TYPO3 v10 LTS

### DIFF
--- a/Classes/ClickMenu.php
+++ b/Classes/ClickMenu.php
@@ -31,6 +31,7 @@ use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\PathUtility;
 use TYPO3\CMS\Lang\LanguageService;
 
 /**
@@ -85,7 +86,7 @@ class ClickMenu
 
                 $localItems[] = $backRef->linkItem(
                     $this->getLanguageService()->getLLL("cm1_title", $LL),
-                    $backRef->excludeIcon('<img src="' . ExtensionManagementUtility::siteRelPath("l10nmgr") . 'cm1/cm_icon.gif" width="15" height="12" border="0" align="top" />'),
+                    $backRef->excludeIcon('<img src="' . PathUtility::getAbsoluteWebPath(GeneralUtility::getFileAbsFileName('EXT:l10nmgr/cm1/cm_icon.gif')) . '" width="15" height="12" border="0" align="top" />'),
                     $backRef->urlRefForCM($url),
                     1 // Disables the item in the top-bar. Set this to zero if you with the item to appear in the top bar!
                 );

--- a/Classes/Command/Export.php
+++ b/Classes/Command/Export.php
@@ -29,6 +29,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Exception;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
@@ -263,7 +264,7 @@ class Export extends L10nCommand
                 $output->writeln('<error>' . $l10nmgrGetXML->renderExportsCli() . LF . '</error>');
             } else {
                 // Save export to XML file
-                $xmlFileName = PATH_site . $l10nmgrGetXML->render();
+                $xmlFileName = Environment::getPublicPath() . '/' . $l10nmgrGetXML->render();
                 $l10nmgrGetXML->saveExportInformation();
                 // If email notification is set send export files to responsible translator
                 if ($lConf['enable_notification'] == 1) {

--- a/Classes/Command/Import.php
+++ b/Classes/Command/Import.php
@@ -32,6 +32,7 @@ use Localizationteam\L10nmgr\Zip;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Exception;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -515,9 +516,9 @@ class Import extends L10nCommand
             if ($filesToDownload != false) {
                 // Check that download directory exists
                 $downloadFolder = 'uploads/tx_l10nmgr/jobs/in/';
-                $downloadPath = PATH_site . $downloadFolder;
+                $downloadPath = Environment::getPublicPath() . '/' . $downloadFolder;
                 if (!is_dir(GeneralUtility::getFileAbsFileName($downloadPath))) {
-                    GeneralUtility::mkdir_deep(PATH_site . $downloadFolder);
+                    GeneralUtility::mkdir_deep($downloadFolder);
                 }
                 foreach ($filesToDownload as $aFile) {
                     // Ignore current directory and reference to upper level

--- a/Classes/Controller/BaseModule.php
+++ b/Classes/Controller/BaseModule.php
@@ -1,0 +1,352 @@
+<?php
+namespace Localizationteam\L10nmgr\Controller;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\Localization\LanguageService;
+use TYPO3\CMS\Core\Messaging\FlashMessage;
+use TYPO3\CMS\Core\Messaging\FlashMessageService;
+use TYPO3\CMS\Core\Page\PageRenderer;
+use TYPO3\CMS\Core\Type\Bitmask\Permission;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Used in "BaseScriptClass" from TYPO3 Core
+ */
+class BaseModule
+{
+    /**
+     * Loaded with the global array $MCONF which holds some module configuration from the conf.php file of backend modules.
+     *
+     * @see init()
+     * @var array
+     */
+    public $MCONF = [];
+
+    /**
+     * The integer value of the GET/POST var, 'id'. Used for submodules to the 'Web' module (page id)
+     *
+     * @see init()
+     * @var int
+     */
+    public $id;
+
+    /**
+     * The value of GET/POST var, 'CMD'
+     *
+     * @see init()
+     * @var mixed
+     */
+    public $CMD;
+
+    /**
+     * A WHERE clause for selection records from the pages table based on read-permissions of the current backend user.
+     *
+     * @see init()
+     * @var string
+     */
+    public $perms_clause;
+
+    /**
+     * The module menu items array. Each key represents a key for which values can range between the items in the array of that key.
+     *
+     * @see init()
+     * @var array
+     */
+    public $MOD_MENU = [
+        'function' => []
+    ];
+
+    /**
+     * Current settings for the keys of the MOD_MENU array
+     *
+     * @see $MOD_MENU
+     * @var array
+     */
+    public $MOD_SETTINGS = [];
+
+    /**
+     * Module TSconfig based on PAGE TSconfig / USER TSconfig
+     *
+     * @see menuConfig()
+     * @var array
+     */
+    public $modTSconfig;
+
+    /**
+     * If type is 'ses' then the data is stored as session-lasting data. This means that it'll be wiped out the next time the user logs in.
+     * Can be set from extension classes of this class before the init() function is called.
+     *
+     * @see menuConfig(), \TYPO3\CMS\Backend\Utility\BackendUtility::getModuleData()
+     * @var string
+     */
+    public $modMenu_type = '';
+
+    /**
+     * dontValidateList can be used to list variables that should not be checked if their value is found in the MOD_MENU array. Used for dynamically generated menus.
+     * Can be set from extension classes of this class before the init() function is called.
+     *
+     * @see menuConfig(), \TYPO3\CMS\Backend\Utility\BackendUtility::getModuleData()
+     * @var string
+     */
+    public $modMenu_dontValidateList = '';
+
+    /**
+     * List of default values from $MOD_MENU to set in the output array (only if the values from MOD_MENU are not arrays)
+     * Can be set from extension classes of this class before the init() function is called.
+     *
+     * @see menuConfig(), \TYPO3\CMS\Backend\Utility\BackendUtility::getModuleData()
+     * @var string
+     */
+    public $modMenu_setDefaultList = '';
+
+    /**
+     * Contains module configuration parts from TBE_MODULES_EXT if found
+     *
+     * @see handleExternalFunctionValue()
+     * @var array
+     */
+    public $extClassConf;
+
+    /**
+     * Generally used for accumulating the output content of backend modules
+     *
+     * @var string
+     */
+    public $content = '';
+
+    /**
+     * @var \TYPO3\CMS\Backend\Template\DocumentTemplate
+     */
+    public $doc;
+
+    /**
+     * May contain an instance of a 'Function menu module' which connects to this backend module.
+     *
+     * @see checkExtObj()
+     * @var AbstractFunctionModule
+     */
+    public $extObj;
+
+    /**
+     * @var PageRenderer
+     */
+    protected $pageRenderer;
+
+    /**
+     * Initializes the backend module by setting internal variables, initializing the menu.
+     *
+     * @see menuConfig()
+     */
+    public function init()
+    {
+        // Name might be set from outside
+        if (!$this->MCONF['name']) {
+            $this->MCONF = $GLOBALS['MCONF'];
+        }
+        $this->id = (int)GeneralUtility::_GP('id');
+        $this->CMD = GeneralUtility::_GP('CMD');
+        $this->perms_clause = $this->getBackendUser()->getPagePermsClause(Permission::PAGE_SHOW);
+        $this->menuConfig();
+        $this->handleExternalFunctionValue();
+    }
+
+    /**
+     * Initializes the internal MOD_MENU array setting and unsetting items based on various conditions. It also merges in external menu items from the global array TBE_MODULES_EXT (see mergeExternalItems())
+     * Then MOD_SETTINGS array is cleaned up (see \TYPO3\CMS\Backend\Utility\BackendUtility::getModuleData()) so it contains only valid values. It's also updated with any SET[] values submitted.
+     * Also loads the modTSconfig internal variable.
+     *
+     * @see init(), $MOD_MENU, $MOD_SETTINGS, \TYPO3\CMS\Backend\Utility\BackendUtility::getModuleData(), mergeExternalItems()
+     */
+    public function menuConfig()
+    {
+        // Page / user TSconfig settings and blinding of menu-items
+        $this->modTSconfig['properties'] = BackendUtility::getPagesTSconfig($this->id)['mod.'][$this->MCONF['name'] . '.'] ?? [];
+        $this->MOD_MENU['function'] = $this->mergeExternalItems($this->MCONF['name'], 'function', $this->MOD_MENU['function']);
+        $blindActions = $this->modTSconfig['properties']['menu.']['function.'] ?? [];
+        foreach ($blindActions as $key => $value) {
+            if (!$value && array_key_exists($key, $this->MOD_MENU['function'])) {
+                unset($this->MOD_MENU['function'][$key]);
+            }
+        }
+        $this->MOD_SETTINGS = BackendUtility::getModuleData($this->MOD_MENU, GeneralUtility::_GP('SET'), $this->MCONF['name'], $this->modMenu_type, $this->modMenu_dontValidateList, $this->modMenu_setDefaultList);
+    }
+
+    /**
+     * Merges menu items from global array $TBE_MODULES_EXT
+     *
+     * @param string $modName Module name for which to find value
+     * @param string $menuKey Menu key, eg. 'function' for the function menu.
+     * @param array $menuArr The part of a MOD_MENU array to work on.
+     * @return array Modified array part.
+     * @internal
+     * @see \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::insertModuleFunction(), menuConfig()
+     */
+    public function mergeExternalItems($modName, $menuKey, $menuArr)
+    {
+        $mergeArray = $GLOBALS['TBE_MODULES_EXT'][$modName]['MOD_MENU'][$menuKey];
+        if (is_array($mergeArray)) {
+            foreach ($mergeArray as $k => $v) {
+                if (((string)$v['ws'] === '' || $this->getBackendUser()->workspace === 0 && GeneralUtility::inList($v['ws'], 'online')) || $this->getBackendUser()->workspace === -1 && GeneralUtility::inList($v['ws'], 'offline') || $this->getBackendUser()->workspace > 0 && GeneralUtility::inList($v['ws'], 'custom')) {
+                    $menuArr[$k] = $this->getLanguageService()->sL($v['title']);
+                }
+            }
+        }
+        return $menuArr;
+    }
+
+    /**
+     * Loads $this->extClassConf with the configuration for the CURRENT function of the menu.
+     *
+     * @param string $MM_key The key to MOD_MENU for which to fetch configuration. 'function' is default since it is first and foremost used to get information per "extension object" (I think that is what its called)
+     * @param string $MS_value The value-key to fetch from the config array. If NULL (default) MOD_SETTINGS[$MM_key] will be used. This is useful if you want to force another function than the one defined in MOD_SETTINGS[function]. Call this in init() function of your Script Class: handleExternalFunctionValue('function', $forcedSubModKey)
+     * @see getExternalItemConfig(), init()
+     */
+    public function handleExternalFunctionValue($MM_key = 'function', $MS_value = null)
+    {
+        if ($MS_value === null) {
+            $MS_value = $this->MOD_SETTINGS[$MM_key];
+        }
+        $this->extClassConf = $this->getExternalItemConfig($this->MCONF['name'], $MM_key, $MS_value);
+    }
+
+    /**
+     * Returns configuration values from the global variable $TBE_MODULES_EXT for the module given.
+     * For example if the module is named "web_info" and the "function" key ($menuKey) of MOD_SETTINGS is "stat" ($value) then you will have the values of $TBE_MODULES_EXT['webinfo']['MOD_MENU']['function']['stat'] returned.
+     *
+     * @param string $modName Module name
+     * @param string $menuKey Menu key, eg. "function" for the function menu. See $this->MOD_MENU
+     * @param string $value Optionally the value-key to fetch from the array that would otherwise have been returned if this value was not set. Look source...
+     * @return mixed The value from the TBE_MODULES_EXT array.
+     * @see handleExternalFunctionValue()
+     */
+    public function getExternalItemConfig($modName, $menuKey, $value = '')
+    {
+        if (isset($GLOBALS['TBE_MODULES_EXT'][$modName])) {
+            return (string)$value !== '' ? $GLOBALS['TBE_MODULES_EXT'][$modName]['MOD_MENU'][$menuKey][$value] : $GLOBALS['TBE_MODULES_EXT'][$modName]['MOD_MENU'][$menuKey];
+        }
+        return null;
+    }
+
+    /**
+     * Creates an instance of the class found in $this->extClassConf['name'] in $this->extObj if any (this should hold three keys, "name", "path" and "title" if a "Function menu module" tries to connect...)
+     * This value in extClassConf might be set by an extension (in an ext_tables/ext_localconf file) which thus "connects" to a module.
+     * The array $this->extClassConf is set in handleExternalFunctionValue() based on the value of MOD_SETTINGS[function]
+     * If an instance is created it is initiated with $this passed as value and $this->extClassConf as second argument. Further the $this->MOD_SETTING is cleaned up again after calling the init function.
+     *
+     * @see handleExternalFunctionValue(), \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::insertModuleFunction(), $extObj
+     */
+    public function checkExtObj()
+    {
+        if (is_array($this->extClassConf) && $this->extClassConf['name']) {
+            $this->extObj = GeneralUtility::makeInstance($this->extClassConf['name']);
+            $this->extObj->init($this, $this->extClassConf);
+            // Re-write:
+            $this->MOD_SETTINGS = BackendUtility::getModuleData($this->MOD_MENU, GeneralUtility::_GP('SET'), $this->MCONF['name'], $this->modMenu_type, $this->modMenu_dontValidateList, $this->modMenu_setDefaultList);
+        }
+    }
+
+    /**
+     * Calls the checkExtObj function in sub module if present.
+     */
+    public function checkSubExtObj()
+    {
+        if (is_object($this->extObj)) {
+            $this->extObj->checkExtObj();
+        }
+    }
+
+    /**
+     * Calls the 'header' function inside the "Function menu module" if present.
+     * A header function might be needed to add JavaScript or other stuff in the head. This can't be done in the main function because the head is already written.
+     */
+    public function extObjHeader()
+    {
+        if (is_callable([$this->extObj, 'head'])) {
+            $this->extObj->head();
+        }
+    }
+
+    /**
+     * Calls the 'main' function inside the "Function menu module" if present
+     */
+    public function extObjContent()
+    {
+        if ($this->extObj === null) {
+            $flashMessage = GeneralUtility::makeInstance(
+                FlashMessage::class,
+                $this->getLanguageService()->sL('LLL:EXT:backend/Resources/Private/Language/locallang.xlf:no_modules_registered'),
+                $this->getLanguageService()->getLL('title'),
+                FlashMessage::ERROR
+            );
+            /** @var \TYPO3\CMS\Core\Messaging\FlashMessageService $flashMessageService */
+            $flashMessageService = GeneralUtility::makeInstance(FlashMessageService::class);
+            /** @var \TYPO3\CMS\Core\Messaging\FlashMessageQueue $defaultFlashMessageQueue */
+            $defaultFlashMessageQueue = $flashMessageService->getMessageQueueByIdentifier();
+            $defaultFlashMessageQueue->enqueue($flashMessage);
+        } else {
+            $this->extObj->pObj = $this;
+            if (is_callable([$this->extObj, 'main'])) {
+                $this->content .= $this->extObj->main();
+            }
+        }
+    }
+
+    /**
+     * Return the content of the 'main' function inside the "Function menu module" if present
+     *
+     * @return string
+     */
+    public function getExtObjContent()
+    {
+        $savedContent = $this->content;
+        $this->content = '';
+        $this->extObjContent();
+        $newContent = $this->content;
+        $this->content = $savedContent;
+        return $newContent;
+    }
+
+    /**
+     * Returns the Language Service
+     * @return LanguageService
+     */
+    protected function getLanguageService()
+    {
+        return $GLOBALS['LANG'];
+    }
+
+    /**
+     * Returns the Backend User
+     * @return BackendUserAuthentication
+     */
+    protected function getBackendUser()
+    {
+        return $GLOBALS['BE_USER'];
+    }
+
+    /**
+     * @return PageRenderer
+     */
+    protected function getPageRenderer()
+    {
+        if ($this->pageRenderer === null) {
+            $this->pageRenderer = GeneralUtility::makeInstance(PageRenderer::class);
+        }
+
+        return $this->pageRenderer;
+    }
+}

--- a/Classes/Controller/Cm2.php
+++ b/Classes/Controller/Cm2.php
@@ -23,12 +23,11 @@ namespace Localizationteam\L10nmgr\Controller;
  * @author Kasper Skårhøj <kasperYYYY@typo3.com>
  */
 use Localizationteam\L10nmgr\Model\Tools\Tools;
-use TYPO3\CMS\Backend\Module\BaseScriptClass;
 use TYPO3\CMS\Backend\Template\DocumentTemplate;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Imaging\IconFactory;
+use TYPO3\CMS\Core\Localization\LanguageService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Lang\LanguageService;
 
 /**
  * Translation management tool
@@ -37,7 +36,7 @@ use TYPO3\CMS\Lang\LanguageService;
  * @packageTYPO3
  * @subpackage tx_l10nmgr
  */
-class Cm2 extends BaseScriptClass
+class Cm2 extends BaseModule
 {
     /**
      * @var LanguageService

--- a/Classes/Controller/Cm3.php
+++ b/Classes/Controller/Cm3.php
@@ -22,8 +22,9 @@ namespace Localizationteam\L10nmgr\Controller\Cm3;
  *
  * @author Kasper Skårhøj <kasperYYYY@typo3.com>
  */
+
+use Localizationteam\L10nmgr\Controller\BaseModule;
 use Localizationteam\L10nmgr\Model\Tools\Tools;
-use TYPO3\CMS\Backend\Module\BaseScriptClass;
 use TYPO3\CMS\Backend\Template\DocumentTemplate;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Utility\DebugUtility;
@@ -36,7 +37,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * @packageTYPO3
  * @subpackage tx_l10nmgr
  */
-class Cm3 extends BaseScriptClass
+class Cm3 extends BaseModule
 {
     /**
      * @var DocumentTemplate

--- a/Classes/Controller/TranslationTasks.php
+++ b/Classes/Controller/TranslationTasks.php
@@ -24,16 +24,16 @@ namespace Localizationteam\L10nmgr\Controller;
  */
 use Localizationteam\L10nmgr\Hooks\Tcemain;
 use Localizationteam\L10nmgr\Model\Tools\Tools;
-use TYPO3\CMS\Backend\Module\BaseScriptClass;
 use TYPO3\CMS\Backend\Template\DocumentTemplate;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Http\HtmlResponse;
 use TYPO3\CMS\Core\Imaging\IconFactory;
-use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\PathUtility;
 
-class TranslationTasks extends BaseScriptClass
+class TranslationTasks extends BaseModule
 {
     /**
      * @var DocumentTemplate
@@ -169,7 +169,7 @@ class TranslationTasks extends BaseScriptClass
                 }
                 $icon = GeneralUtility::makeInstance(IconFactory::class)->getIconForRecord($el[0], $rec_on);
                 $icon = BackendUtility::wrapClickMenuOnIcon($icon, $el[0], $rec_on['uid'], 2);
-                $linkToIt = '<a href="#" onclick="' . htmlspecialchars('parent.list_frame.location.href="' . $GLOBALS['BACK_PATH'] . ExtensionManagementUtility::siteRelPath('l10nmgr') . 'cm2/index.php?table=' . $el[0] . '&uid=' . $el[1] . '"; return false;') . '" target="listframe">
+                $linkToIt = '<a href="#" onclick="' . htmlspecialchars('parent.list_frame.location.href="' . PathUtility::getAbsoluteWebPath(GeneralUtility::getFileAbsFileName('EXT:l10nmgr')) . 'cm2/index.php?table=' . $el[0] . '&uid=' . $el[1] . '"; return false;') . '" target="listframe">
 	' . BackendUtility::getRecordTitle($el[0], $rec_on, true) . '
 	</a>';
                 if ($el[0] == 'pages') {
@@ -177,7 +177,7 @@ class TranslationTasks extends BaseScriptClass
                     $newPageModule = trim($this->getBackendUser()->getTSConfigVal('options.overridePageModule'));
                     $pageModule = BackendUtility::isModuleSetInTBE_MODULES($newPageModule) ? $newPageModule : 'web_layout';
                     $path_module_path = GeneralUtility::resolveBackPath($GLOBALS['BACK_PATH'] . '../' . substr($GLOBALS['TBE_MODULES']['_PATHS'][$pageModule],
-                            strlen(PATH_site)));
+                            strlen(Environment::getPublicPath() . '/')));
                     $onclick = 'parent.list_frame.location.href="' . $path_module_path . '?id=' . $el[1] . '"; return false;';
                     $pmLink = '<a href="#" onclick="' . htmlspecialchars($onclick) . '" target="listframe"><i>[Edit page]</i></a>';
                 } else {

--- a/Classes/Hooks/Tcemain.php
+++ b/Classes/Hooks/Tcemain.php
@@ -36,6 +36,7 @@ use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\PathUtility;
 
 /**
  * Hook for updating translation index
@@ -227,6 +228,6 @@ class Tcemain
     protected function siteRelPath($extensionKey)
     {
         $path = ExtensionManagementUtility::extPath($extensionKey);
-        return substr($path, strlen(Environment::getPublicPath() . '/'));
+        return PathUtility::getAbsoluteWebPath($path);
     }
 }

--- a/Classes/Model/Tools/XmlTools.php
+++ b/Classes/Model/Tools/XmlTools.php
@@ -63,7 +63,7 @@ class XmlTools implements LoggerAwareInterface
         // First call special transformations (registered using hooks)
         if (is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['l10nmgr']['transformation'])) {
             foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['l10nmgr']['transformation'] as $classReference) {
-                $processingObject = GeneralUtility::getUserObj($classReference);
+                $processingObject = GeneralUtility::makeInstance($classReference);
                 $content = $processingObject->transform_rte($content, $this->parseHTML);
             }
         }

--- a/Classes/Task/LocalizationmanagerFileGarbageCollectionAdditionalFieldProvider.php
+++ b/Classes/Task/LocalizationmanagerFileGarbageCollectionAdditionalFieldProvider.php
@@ -21,7 +21,7 @@ namespace Localizationteam\L10nmgr\Task;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Messaging\FlashMessage;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Lang\LanguageService;
+use TYPO3\CMS\Core\Localization\LanguageService;
 use TYPO3\CMS\Scheduler\AdditionalFieldProviderInterface;
 use TYPO3\CMS\Scheduler\Controller\SchedulerModuleController;
 use TYPO3\CMS\Scheduler\Task\AbstractTask;

--- a/Classes/View/AbstractExportView.php
+++ b/Classes/View/AbstractExportView.php
@@ -25,6 +25,7 @@ namespace Localizationteam\L10nmgr\View;
 use Localizationteam\L10nmgr\Model\L10nConfiguration;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Messaging\FlashMessage;
 use TYPO3\CMS\Core\Messaging\FlashMessageRendererResolver;
@@ -387,7 +388,7 @@ abstract class AbstractExportView
                 $exportData['l10ncfg_id'],
                 $exportData['exportType'],
                 $exportData['translation_lang'],
-                sprintf('%suploads/tx_l10nmgr/jobs/out/%s', PATH_site, $exportData['filename'])
+                sprintf('%suploads/tx_l10nmgr/jobs/out/%s', Environment::getPublicPath() . '/', $exportData['filename'])
             );
         }
         $out = sprintf(
@@ -412,7 +413,11 @@ abstract class AbstractExportView
     public function saveExportFile($fileContent)
     {
         $fileExportName = 'uploads/tx_l10nmgr/jobs/out/' . $this->getFilename();
-        GeneralUtility::writeFile(PATH_site . $fileExportName, $fileContent);
+        $fullFile = Environment::getPublicPath() . '/' . $fileExportName;
+        if (!is_dir(dirname($fullFile))) {
+            GeneralUtility::mkdir_deep(dirname($fullFile));
+        }
+        GeneralUtility::writeFile($fullFile, $fileContent);
         return $fileExportName;
     }
 

--- a/Classes/View/CatXmlView.php
+++ b/Classes/View/CatXmlView.php
@@ -186,7 +186,7 @@ class CatXmlView extends AbstractExportView implements ExportViewInterface
         // Provide a hook for specific manipulations before building the actual XML
         if (is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['l10nmgr']['exportCatXmlPreProcess'])) {
             foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['l10nmgr']['exportCatXmlPreProcess'] as $classReference) {
-                $processingObject = GeneralUtility::getUserObj($classReference);
+                $processingObject = GeneralUtility::makeInstance($classReference);
                 $output = $processingObject->processBeforeExportingCatXml($output, $this);
             }
         }

--- a/Classes/View/ExcelXmlView.php
+++ b/Classes/View/ExcelXmlView.php
@@ -192,7 +192,7 @@ class ExcelXmlView extends AbstractExportView implements ExportViewInterface
         // Provide a hook for specific manipulations before building the actual XML
         if (is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['l10nmgr']['exportExcelXmlPreProcess'])) {
             foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['l10nmgr']['exportExcelXmlPreProcess'] as $classReference) {
-                $processingObject = GeneralUtility::getUserObj($classReference);
+                $processingObject = GeneralUtility::makeInstance($classReference);
                 $output = $processingObject->processBeforeExportingExcelXml($output, $this);
             }
         }

--- a/Classes/View/L10nConfigurationDetailView.php
+++ b/Classes/View/L10nConfigurationDetailView.php
@@ -22,7 +22,7 @@ use Localizationteam\L10nmgr\Model\L10nConfiguration;
 use TYPO3\CMS\Backend\Template\DocumentTemplate;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Lang\LanguageService;
+use TYPO3\CMS\Core\Localization\LanguageService;
 
 /**
  * l10nmgr detail view:

--- a/Classes/Zip.php
+++ b/Classes/Zip.php
@@ -2,6 +2,7 @@
 
 namespace Localizationteam\L10nmgr;
 
+use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -169,7 +170,7 @@ class Zip
     public function extractFile($file)
     {
         if (is_file($file)) {
-            $tempDir = PATH_site . 'typo3temp/' . md5(microtime()) . '/';
+            $tempDir = Environment::getPublicPath() . '/typo3temp/' . md5(microtime()) . '/';
             GeneralUtility::mkdir($tempDir);
             if (is_dir($tempDir)) {
                 // This is if I want to check the content:
@@ -227,7 +228,7 @@ class Zip
      */
     public function removeDir($tempDir)
     {
-        $testDir = PATH_site . 'typo3temp/';
+        $testDir = Environment::getPublicPath() . '/typo3temp/';
         if (!GeneralUtility::isFirstPartOfStr($tempDir, $testDir)) {
             die($tempDir . ' was not within ' . $testDir);
         }

--- a/composer.json
+++ b/composer.json
@@ -5,12 +5,11 @@
 	"homepage": "https://docs.typo3.org/typo3cms/extensions/l10nmgr/",
 	"license": ["GPL-2.0-or-later"],
 	"keywords": ["TYPO3 CMS", "L10N", "I18N", "T9N", "localization", "translation", "internationalization", "language"],
-	"support": {
-		"issues": "https://forge.typo3.org/projects/extension-l10nmgr/issues"
-	},
 	"require": {
-		"sjbr/static-info-tables": "^6.7.0",
-		"typo3/cms-core": "^9.5.0"
+		"typo3/cms-core": "^9.5.0 || ^10.0.0"
+	},
+	"suggest": {
+		"sjbr/static-info-tables": "Additional information stored into meta information when exporting"
 	},
 	"autoload": {
 		"psr-4": {
@@ -18,7 +17,11 @@
 		}
 	},
 	"replace": {
-		"l10nmgr": "self.version",
 		"typo3-ter/l10nmgr": "self.version"
+	},
+	"extra": {
+		"typo3/cms": {
+			"extension-key": "l10nmgr"
+		}
 	}
 }

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -14,10 +14,11 @@ $EM_CONF[$_EXTKEY] = [
     'author_company' => 'Localization Manager Team',
     'constraints' => [
         'depends' => [
-            'typo3' => '9.5.0',
-            'static_info_tables' => '6.4.2-0.0.0'
+            'typo3' => '9.5.0-10.4.99'
         ],
         'conflicts' => [],
-        'suggests' => []
+        'suggests' => [
+            'static_info_tables' => '6.4.2-0.0.0'
+        ]
     ]
 ];


### PR DESCRIPTION
* Use Environment API
* Copy TYPO3 Core BaseScriptClass as BaseModule class
* Avoid scriptRelPath
* Use proper request/response handling in PSR-15 RequestHandlers
* Remove requirement to static_info_tables (now only as a suggest)